### PR TITLE
Add version reports to pyct

### DIFF
--- a/pyct/report.py
+++ b/pyct/report.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# Import and print the library version and filesystem location for each Python package or shell command specified
+#
+# bash usage: $ autover numpy pandas python conda
+# python usage: >>> import autover ; autover("numpy","pandas","python","conda")
+
+from __future__ import print_function
+import os.path, importlib, subprocess, platform, sys
+
+def autover(*packages):
+    """Import and print location and version information for specified Python packages"""
+    accepted_commands = ['python','conda']
+    for package in packages:
+        loc = "not installed in this environment"
+        ver = "unknown"
+
+        try:
+            module = importlib.import_module(package)
+            loc =  os.path.dirname(module.__file__)
+
+            try:
+                ver = str(module.__version__)
+            except Exception:
+                pass
+        
+        except (ImportError, ModuleNotFoundError):
+            if package in accepted_commands:
+                try:
+                    # See if there is a command by that name and check its --version if so
+                    loc = subprocess.check_output(['which', package]).decode().strip()
+                    out = ""
+                    try:
+                        out = subprocess.check_output([package, '--version'], stderr=subprocess.STDOUT)
+                    except subprocess.CalledProcessError as e:
+                        out = e.output
+
+                    # Assume first word in output with a period and digits is the version
+                    for s in out.decode().split():
+                        if '.' in s and str.isdigit(s[0]) and sum(str.isdigit(c) for c in s)>=2:
+                            ver=s.strip()
+                            break
+                except Exception as e:
+                    pass
+            elif package == 'system':
+                try:
+                    ver = platform.platform()
+                    loc = 'OS'
+                except Exception:
+                    pass
+            else:
+                pass
+        
+        print("{0:30} # {1}".format(package + "=" + ver,loc))
+
+
+def main():
+    autover(*(sys.argv[1:]))
+    
+if __name__ == "__main__":
+    main()
+    

--- a/pyct/tests/test_report.py
+++ b/pyct/tests/test_report.py
@@ -1,0 +1,50 @@
+from unittest.mock import Mock, patch
+from pyct.report import report
+
+class TestModule:
+    __version__ = "1.9.3"
+    __file__ = "/Users/kbowen/opt/anaconda3/envs/pyct/lib/python3.7/site-packages/param/__init__.py"
+
+@patch("builtins.print")
+@patch("importlib.import_module")
+def test_report_gives_package_version(mock_import_module, mock_print):
+    module = TestModule()
+    mock_import_module.return_value = module
+    
+    report("param")
+    
+    mock_print.assert_called_with('param=1.9.3                    # /Users/kbowen/opt/anaconda3/envs/pyct/lib/python3.7/site-packages/param')
+
+@patch("builtins.print")
+@patch("subprocess.check_output")
+def test_report_gives_conda_version(mock_check_output, mock_print):
+    mock_check_output.side_effect = [b'/Users/kbowen/opt/anaconda3/condabin/conda\n', b'conda 4.8.3\n']
+
+    report("conda")
+
+    mock_print.assert_called_with("conda=4.8.3                    # /Users/kbowen/opt/anaconda3/condabin/conda")
+    
+
+@patch("builtins.print")
+@patch("subprocess.check_output")
+def test_report_gives_python_version(mock_check_output, mock_print):
+    mock_check_output.side_effect = [b'/Users/kbowen/opt/anaconda3/envs/pyct/bin/python\n', b'Python 3.7.7\n']
+
+    report("python")
+
+    mock_print.assert_called_with("python=3.7.7                   # /Users/kbowen/opt/anaconda3/envs/pyct/bin/python")
+
+@patch("builtins.print")
+@patch("platform.platform")
+def test_report_gives_system_version(mock_platform, mock_print):
+    mock_platform.return_value = "Darwin-19.2.0-x86_64-i386-64bit"
+
+    report("system")
+
+    mock_print.assert_called_with("system=Darwin-19.2.0-x86_64-i386-64bit # OS")
+
+@patch("builtins.print")
+def test_unknown_package_output(mock_print):
+    report("fake_package")
+    
+    mock_print.assert_called_with("fake_package=unknown           # not installed in this environment")

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,11 @@ setup_args = dict(
             "setuptools",
             "param >=1.7.0",
         ]
+    },
+    entry_points = {
+        'console_scripts': [
+            'report = pyct.report:main',
+        ],
     }
 )
 


### PR DESCRIPTION
@jbednar @jlstevens @philippjfr I added the version report script from autover to pyct and set it up as a console script, and I also added unit tests for the report script. Master seems to be having some issues related to the Python version in Travis: 
`0.04s$ pip install pyctdev && doit ecosystem_setup
pyenv: version `3.6' is not installed (set by PYENV_VERSION environment variable)
The command "pip install pyctdev && doit ecosystem_setup" failed and exited with 1 during .`

Does anyone have any thoughts on how to fix this issue?