### PR TITLE
Use shell=True for finding commands.

### DIFF
--- a/pyct/report.py
+++ b/pyct/report.py
@@ -28,10 +28,10 @@ def report(*packages):
                 try:
                     # See if there is a command by that name and check its --version if so
                     try:
-                        loc = subprocess.check_output(['command','-v',      package]).decode().splitlines()[0].strip()
+                        loc = subprocess.check_output('command -v {}'.format(package), shell=True).decode().splitlines()[0].strip()
                     except:
                         # .exe in case powershell (otherwise wouldn't need it)
-                        loc = subprocess.check_output(['where.exe',       package]).decode().splitlines()[0].strip()                    
+                        loc = subprocess.check_output( 'where.exe {}'.format(package), shell=True).decode().splitlines()[0].strip()                    
                     out = ""
                     try:
                         out = subprocess.check_output([package, '--version'], stderr=subprocess.STDOUT)


### PR DESCRIPTION
Fix #88 (which has discussion of this change)

Using shell=True with a string was tested on linux in #88 
Using shell=True with a string was tested on mac in #88 

Using shell=True probably makes no difference on windows either way, but enables passing a string rather than a list, which _could_ make a difference (a list is subject to python's interpretation of how to join into a string suitable for windows - not that it will make much difference for our use).