### PR TITLE
Use license_files instead of the deprecated license_file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup_args = dict(
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     license='BSD 3-Clause License',
-    license_file='LICENSE.txt',
+    license_files=['LICENSE.txt'],
     classifiers = [
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
The setuptools `license_file` key is [deprecated](https://setuptools.pypa.io/en/latest/deprecated/changed_keywords.html?highlight=license_files#new-and-changed-setup-keywords). Use `license_files` instead, that accept a list of license files.