### PR TITLE
Drop Python 2 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,9 @@ setup_args = dict(
         'Development Status :: 4 - Beta'
     ],
     author='HoloViz',
-    author_email='holoviews@gmail.com',
+    author_email='developers@holoviz.org',
     maintainer='HoloViz',
-    maintainer_email='holoviews@gmail.com',
+    maintainer_email='developers@holoviz.org',
     url='https://github.com/pyviz-dev/{}'.format(NAME),
     project_urls = {
         'Bug Tracker': 'https://github.com/pyviz-dev/{}/issues'.format(NAME),

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,11 @@ setup_args = dict(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Development Status :: 4 - Beta'
     ],
     author='HoloViz',
@@ -57,7 +60,7 @@ setup_args = dict(
     },
     include_package_data=True,
     packages=find_packages(),
-    python_requires='>=2.7',
+    python_requires='>=3.6',
     install_requires=[
         'param >=1.7.0',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py36,py37,py38,py39,py310}-{flakes,unit,cmd_examples,build_examples,all}-{default}-{dev,pkg}
+envlist = {py36,py37,py38,py39,py310}-{flakes,unit,cmd_examples,build_examples,all}-{default}-{dev,pkg}
 build = wheel
 
 [_flakes]


### PR DESCRIPTION
Preparing a new release to fix a few deprecation warnings. Suggesting to release Python 2 at the same time.