### PR TITLE
Ensure tox envs that run tests depend on cmd extra

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,11 +21,11 @@ commands = {[_flakes]commands}
            {[_unit]commands}
            {[_cmd_examples]commands}
            {[_build_examples]commands}
-deps = .[examples, tests]
+deps = .[examples,tests,cmd]
 
 [_unit]
 description = Run unit tests
-deps = .[tests]
+deps = .[tests,cmd]
 commands = pytest pyct
            pyct --help
            pyct --version


### PR DESCRIPTION
Fixes errors like:

```
py36-unit-default-dev run-test: commands[0] | pytest pyct
============================================== test session starts ===============================================
platform linux -- Python 3.6.15, pytest-7.0.1, pluggy-1.0.0 -- /home/ben/src/forks/pyct/.tox/py36-unit-default-dev/bin/python
cachedir: .tox/py36-unit-default-dev/.pytest_cache
rootdir: /home/ben/src/forks/pyct, configfile: tox.ini
collected 5 items / 1 error / 4 selected                                                                         

===================================================== ERRORS =====================================================
_________ ERROR collecting .tox/py36-unit-default-dev/lib/python3.6/site-packages/pyct/tests/test_cmd.py _________
ImportError while importing test module '/home/ben/src/forks/pyct/.tox/py36-unit-default-dev/lib/python3.6/site-packages/pyct/tests/test_cmd.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib64/python3.6/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
../lib/python3.6/site-packages/pyct/tests/test_cmd.py:3: in <module>
    import pyct.cmd
../lib/python3.6/site-packages/pyct/cmd.py:81: in <module>
    import yaml
E   ModuleNotFoundError: No module named 'yaml'
============================================ short test summary info =============================================
ERROR ../lib/python3.6/site-packages/pyct/tests/test_cmd.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
================================================ 1 error in 0.09s ================================================
ERROR: InvocationError for command /home/ben/src/forks/pyct/.tox/py36-unit-default-dev/bin/pytest pyct (exited with code 2)
```

when simply running `tox` in a fresh checkout.