### PR TITLE
General maintenance

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     timeout-minutes: 45
     defaults:
       run:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,8 +37,6 @@ jobs:
         run: |
           python -m pip install --upgrade setuptools pip wheel
           python -m pip install "tox<4" tox-gh-actions
-      - name: install test deps
-        run: doit develop_install -o cmd -o tests
       - name: flakes
         run: tox -e _flakes
       - name: unit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     timeout-minutes: 45
     defaults:
       run:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,8 +23,8 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-    env:
-      SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
+    # env:
+    #   SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,8 +34,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: setup
         run: |
-          python -m pip install --upgrade setuptools pip wheel
-          python -m pip install "tox<4" tox-gh-actions
+          python3 -m pip install --upgrade setuptools pip wheel
+          python3 -m pip install "tox<4" tox-gh-actions
       - name: flakes
         run: tox -e flakes
       - name: unit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,6 @@ jobs:
       run:
         shell: bash -l {0}
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
     steps:
       - uses: actions/checkout@v3
@@ -38,10 +37,10 @@ jobs:
           python -m pip install --upgrade setuptools pip wheel
           python -m pip install "tox<4" tox-gh-actions
       - name: flakes
-        run: tox -e _flakes
+        run: tox -e flakes
       - name: unit
-        run: tox -e _unit
+        run: tox -e unit
       - name: _cmd_examples
-        run: tox -e _cmd_examples
+        run: tox -e cmd_examples
       - name: _build_examples
-        run: tox -e _build_examples
+        run: tox -e build_examples

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,21 +29,21 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: "1"
+          fetch-depth: "100"
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: setup pyctdev
+      - name: setup
         run: |
-          python3 -m pip install --upgrade setuptools pip wheel
-          python3 -m pip install pyctdev
+          python -m pip install --upgrade setuptools pip wheel
+          python -m pip install "tox<4" tox-gh-actions
       - name: install test deps
         run: doit develop_install -o cmd -o tests
-      - name: doit test_flakes
-        run: doit test_flakes
-      - name: doit test_unit
-        run: doit test_unit
-      - name: doit test_cmd_examples
-        run: doit test_cmd_examples
-      - name: doit test_build_examples
-        run: doit test_build_examples
+      - name: flakes
+        run: tox -e _flakes
+      - name: unit
+        run: tox -e _unit
+      - name: _cmd_examples
+        run: tox -e _cmd_examples
+      - name: _build_examples
+        run: tox -e _build_examples

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "100"
+      - name: fetch tags
+        run: git fetch --tags
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ venv/
 
 # autover
 */.version
+
+build/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = [
     "param >=1.7.0",
-    "setuptools >=30.3.0"
+    "setuptools >=61.0"
 ]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[metadata]
-license_file = LICENSE.txt
-
-[wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup_args = dict(
     },
     include_package_data=True,
     packages=find_packages(),
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=[
         'param >=1.7.0',
     ],

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup_args = dict(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,14 @@
 envlist = {py37,py38,py39,py310,py311}-{flakes,unit,cmd_examples,build_examples,all}-{default}-{dev,pkg}
 build = wheel
 
+[gh-actions]
+python =
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
+
 [_flakes]
 commands = flake8
 deps = .[tests]

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ commands = pytest pyct
            python3 -m pyct --version
 
 [testenv]
+usedevelop = true
 changedir = {envtmpdir}
 
 commands = unit: {[_unit]commands}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38,py39,py310,py311}-{flakes,unit,cmd_examples,build_examples,all}-{default}-{dev,pkg}
+envlist = {py37,py38,py39,py310,py311}-{flakes,unit,cmd_examples,build_examples,all}-{default}-{dev,pkg}
 build = wheel
 
 [_flakes]

--- a/tox.ini
+++ b/tox.ini
@@ -16,12 +16,12 @@ deps = .[tests]
 
 [_cmd_examples]
 commands = pytest pyct
-           python3 -c "import pyct; pyct.report('pyct','python','system')"
+           {envpython} -c "import pyct; pyct.report('pyct','python','system')"
 deps = .[tests,cmd]
 
 [_build_examples]
 # TODO: not much of a test yet...
-commands = python3 -c "from pyct.build import examples, get_setup_version"
+commands = {envpython} -c "from pyct.build import examples, get_setup_version"
 deps = .[tests]
 
 [_all]

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ deps = .[examples,tests,cmd]
 [_unit]
 description = Run unit tests
 deps = .[tests,cmd]
+allowlist_externals = *
 commands = pytest pyct
            pyct --help
            pyct --version

--- a/tox.ini
+++ b/tox.ini
@@ -34,13 +34,12 @@ deps = .[examples,tests,cmd]
 [_unit]
 description = Run unit tests
 deps = .[tests,cmd]
-allowlist_externals = *
 commands = pytest pyct
            pyct --help
            pyct --version
            pyct report --help           
            pyct report pyct python
-           python3 -m pyct --version
+           {envpython} -m pyct --version
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
- Run the tests with tox only: the test suite was broken for a while running it the previous way, and re-packagers apparently ran tox directly so doing the same in this PR
- remove useless setup.cfg
- Drop support for Python 3.6 and add support for Python 3.11 by including it in the test suite